### PR TITLE
Enable planner tests to create output directory

### DIFF
--- a/path_planner/.gitignore
+++ b/path_planner/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/output/

--- a/path_planner/CMakeLists.txt
+++ b/path_planner/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(PathPlanner)
+
+set(CMAKE_CXX_STANDARD 17)
+
+include_directories(include)
+
+add_library(planner
+    src/AreaGridPlanner.cpp
+    src/CorridorStripPlanner.cpp)
+
+add_executable(test_planner
+    tests/test_planner.cpp)
+
+target_link_libraries(test_planner planner)

--- a/path_planner/README.md
+++ b/path_planner/README.md
@@ -1,0 +1,34 @@
+# Path Planner
+
+This folder contains a minimal C++ reimplementation of the area/grid and corridor/strip planning algorithms from QGroundControl. The code provides:
+
+- `AreaGridPlanner` – generates parallel transects covering a polygon.
+- `CorridorStripPlanner` – generates offset transects along a polyline.
+- Simple unit tests writing the resulting transects to text files in the `output/` directory.
+- `python/plot_transects.py` – script that plots the generated transects with matplotlib.
+
+## Building
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+## Running tests
+
+```bash
+./test_planner
+```
+
+This will generate `output/area_transects.txt` and `output/corridor_transects.txt`.
+
+## Plotting results
+
+After running the tests, execute:
+
+```bash
+python ../python/plot_transects.py ../output
+```
+
+which will create `area.png` and `corridor.png` images with the transects.

--- a/path_planner/include/AreaGridPlanner.h
+++ b/path_planner/include/AreaGridPlanner.h
@@ -1,0 +1,27 @@
+#ifndef AREA_GRID_PLANNER_H
+#define AREA_GRID_PLANNER_H
+
+#include <vector>
+#include <utility>
+#include "Point.h"
+
+class AreaGridPlanner {
+public:
+    AreaGridPlanner(const std::vector<Point>& polygon,
+                    double spacing,
+                    double angle_deg);
+
+    std::vector<std::pair<Point, Point>> generate();
+
+private:
+    Point rotatePoint(const Point& pt, const Point& origin, double angle_rad) const;
+    bool lineIntersect(const Point& p1, const Point& p2,
+                       const Point& q1, const Point& q2,
+                       Point& result) const;
+
+    std::vector<Point> _polygon;
+    double _spacing;
+    double _angleDeg;
+};
+
+#endif // AREA_GRID_PLANNER_H

--- a/path_planner/include/CorridorStripPlanner.h
+++ b/path_planner/include/CorridorStripPlanner.h
@@ -1,0 +1,24 @@
+#ifndef CORRIDOR_STRIP_PLANNER_H
+#define CORRIDOR_STRIP_PLANNER_H
+
+#include <vector>
+#include <utility>
+#include "Point.h"
+
+class CorridorStripPlanner {
+public:
+    CorridorStripPlanner(const std::vector<Point>& polyline,
+                         double width,
+                         double spacing);
+
+    std::vector<std::vector<Point>> generate();
+
+private:
+    Point offsetPoint(const Point& p1, const Point& p2, double offset) const;
+
+    std::vector<Point> _polyline;
+    double _width;
+    double _spacing;
+};
+
+#endif // CORRIDOR_STRIP_PLANNER_H

--- a/path_planner/include/Point.h
+++ b/path_planner/include/Point.h
@@ -1,0 +1,9 @@
+#ifndef POINT_H
+#define POINT_H
+
+struct Point {
+    double x;
+    double y;
+};
+
+#endif // POINT_H

--- a/path_planner/python/plot_transects.py
+++ b/path_planner/python/plot_transects.py
@@ -1,0 +1,48 @@
+import matplotlib.pyplot as plt
+import sys
+import os
+
+
+def plot_area(file_path, out_png):
+    lines = []
+    with open(file_path, 'r') as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) == 4:
+                x1, y1, x2, y2 = map(float, parts)
+                lines.append([(x1, y1), (x2, y2)])
+    for seg in lines:
+        xs, ys = zip(*seg)
+        plt.plot(xs, ys, 'b-')
+    plt.title('Area Grid Transects')
+    plt.axis('equal')
+    plt.savefig(out_png)
+    plt.clf()
+
+
+def plot_corridor(file_path, out_png):
+    with open(file_path, 'r') as f:
+        for line in f:
+            pts = []
+            for pair in line.strip().split(','):
+                if not pair:
+                    continue
+                x, y = map(float, pair.split())
+                pts.append((x, y))
+            xs, ys = zip(*pts)
+            plt.plot(xs, ys, 'g-')
+    plt.title('Corridor Transects')
+    plt.axis('equal')
+    plt.savefig(out_png)
+    plt.clf()
+
+
+def main():
+    out_dir = sys.argv[1] if len(sys.argv) > 1 else 'output'
+    os.makedirs(out_dir, exist_ok=True)
+    plot_area(os.path.join(out_dir, 'area_transects.txt'), os.path.join(out_dir, 'area.png'))
+    plot_corridor(os.path.join(out_dir, 'corridor_transects.txt'), os.path.join(out_dir, 'corridor.png'))
+
+
+if __name__ == '__main__':
+    main()

--- a/path_planner/src/AreaGridPlanner.cpp
+++ b/path_planner/src/AreaGridPlanner.cpp
@@ -1,0 +1,114 @@
+#include "AreaGridPlanner.h"
+#include <cmath>
+#include <algorithm>
+
+AreaGridPlanner::AreaGridPlanner(const std::vector<Point>& polygon,
+                                 double spacing,
+                                 double angle_deg)
+    : _polygon(polygon)
+    , _spacing(spacing)
+    , _angleDeg(angle_deg)
+{
+}
+
+static double rad(double deg) { return deg * M_PI / 180.0; }
+
+Point AreaGridPlanner::rotatePoint(const Point& pt, const Point& origin, double angle_rad) const
+{
+    double s = std::sin(angle_rad);
+    double c = std::cos(angle_rad);
+    Point p;
+    double x = pt.x - origin.x;
+    double y = pt.y - origin.y;
+    p.x = origin.x + x * c - y * s;
+    p.y = origin.y + x * s + y * c;
+    return p;
+}
+
+bool AreaGridPlanner::lineIntersect(const Point& p1, const Point& p2,
+                                    const Point& q1, const Point& q2,
+                                    Point& result) const
+{
+    double s1_x = p2.x - p1.x;
+    double s1_y = p2.y - p1.y;
+    double s2_x = q2.x - q1.x;
+    double s2_y = q2.y - q1.y;
+    double denom = (-s2_x * s1_y + s1_x * s2_y);
+    if (std::abs(denom) < 1e-6) {
+        return false;
+    }
+    double s = (-s1_y * (p1.x - q1.x) + s1_x * (p1.y - q1.y)) / denom;
+    double t = ( s2_x * (p1.y - q1.y) - s2_y * (p1.x - q1.x)) / denom;
+    if (s >= 0 && s <= 1 && t >= 0 && t <= 1) {
+        result.x = p1.x + (t * s1_x);
+        result.y = p1.y + (t * s1_y);
+        return true;
+    }
+    return false;
+}
+
+std::vector<std::pair<Point, Point>> AreaGridPlanner::generate()
+{
+    std::vector<std::pair<Point, Point>> transects;
+    if (_polygon.size() < 3) {
+        return transects;
+    }
+
+    // bounding rect
+    double minx = _polygon[0].x, maxx = _polygon[0].x;
+    double miny = _polygon[0].y, maxy = _polygon[0].y;
+    for (const Point& p : _polygon) {
+        minx = std::min(minx, p.x);
+        maxx = std::max(maxx, p.x);
+        miny = std::min(miny, p.y);
+        maxy = std::max(maxy, p.y);
+    }
+    Point center{ (minx + maxx) / 2.0, (miny + maxy) / 2.0 };
+    double length = std::max(maxx - minx, maxy - miny) + 2.0 * _spacing;
+    double half = length / 2.0;
+
+    // generate parallel lines
+    for (double x = center.x - half; x <= center.x + half; x += _spacing) {
+        Point start{ x, center.y - half };
+        Point end{ x, center.y + half };
+        start = rotatePoint(start, center, rad(_angleDeg));
+        end = rotatePoint(end, center, rad(_angleDeg));
+
+        // intersect with polygon
+        std::vector<Point> intersections;
+        for (size_t i = 0; i < _polygon.size(); ++i) {
+            Point a = _polygon[i];
+            Point b = _polygon[(i + 1) % _polygon.size()];
+            Point inter;
+            if (lineIntersect(start, end, a, b, inter)) {
+                intersections.push_back(inter);
+            }
+        }
+        if (intersections.size() >= 2) {
+            // choose two farthest points
+            Point p1 = intersections[0];
+            Point p2 = intersections[1];
+            double maxDist = (p2.x-p1.x)*(p2.x-p1.x)+(p2.y-p1.y)*(p2.y-p1.y);
+            for (size_t i=0;i<intersections.size();++i) {
+                for (size_t j=i+1;j<intersections.size();++j) {
+                    double d = (intersections[j].x-intersections[i].x)*(intersections[j].x-intersections[i].x)+
+                               (intersections[j].y-intersections[i].y)*(intersections[j].y-intersections[i].y);
+                    if (d > maxDist) {
+                        maxDist = d;
+                        p1 = intersections[i];
+                        p2 = intersections[j];
+                    }
+                }
+            }
+            transects.push_back({p1,p2});
+        }
+    }
+
+    // lawnmower pattern
+    for (size_t i=0;i<transects.size();++i) {
+        if (i % 2 == 1) {
+            std::swap(transects[i].first, transects[i].second);
+        }
+    }
+    return transects;
+}

--- a/path_planner/src/CorridorStripPlanner.cpp
+++ b/path_planner/src/CorridorStripPlanner.cpp
@@ -1,0 +1,61 @@
+#include "CorridorStripPlanner.h"
+#include <cmath>
+#include <algorithm>
+
+CorridorStripPlanner::CorridorStripPlanner(const std::vector<Point>& polyline,
+                                           double width,
+                                           double spacing)
+    : _polyline(polyline)
+    , _width(width)
+    , _spacing(spacing)
+{
+}
+
+Point CorridorStripPlanner::offsetPoint(const Point& p1, const Point& p2, double offset) const
+{
+    double dx = p2.x - p1.x;
+    double dy = p2.y - p1.y;
+    double len = std::sqrt(dx*dx + dy*dy);
+    if (len == 0) {
+        return p1;
+    }
+    double nx = -dy / len;
+    double ny = dx / len;
+    Point result{ p1.x + nx * offset, p1.y + ny * offset };
+    return result;
+}
+
+std::vector<std::vector<Point>> CorridorStripPlanner::generate()
+{
+    std::vector<std::vector<Point>> transects;
+    if (_polyline.size() < 2) {
+        return transects;
+    }
+
+    int count = std::max(1, static_cast<int>(std::floor(_width / _spacing)));
+    double half = _width / 2.0;
+    double startOffset = count == 1 ? 0.0 : -half + _spacing / 2.0;
+
+    for (int i=0;i<count;i++) {
+        double offset = startOffset + i * _spacing;
+        std::vector<Point> transect;
+        for (size_t j=0;j<_polyline.size();++j) {
+            if (j+1 < _polyline.size()) {
+                transect.push_back(offsetPoint(_polyline[j], _polyline[j+1], offset));
+            } else {
+                // last point use previous segment direction
+                transect.push_back(offsetPoint(_polyline[j-1], _polyline[j], offset));
+            }
+        }
+        transects.push_back(transect);
+    }
+
+    // lawnmower pattern
+    for (size_t i=0;i<transects.size();++i) {
+        if (i % 2 == 1) {
+            std::reverse(transects[i].begin(), transects[i].end());
+        }
+    }
+
+    return transects;
+}

--- a/path_planner/tests/test_planner.cpp
+++ b/path_planner/tests/test_planner.cpp
@@ -1,0 +1,36 @@
+#include "AreaGridPlanner.h"
+#include "CorridorStripPlanner.h"
+#include <fstream>
+#include <cassert>
+#include <filesystem>
+
+int main() {
+    std::filesystem::create_directories("output");
+    // Area grid test
+    std::vector<Point> polygon = {{0,0},{100,0},{100,50},{0,50}};
+    AreaGridPlanner areaPlanner(polygon, 20.0, 0.0);
+    auto transects = areaPlanner.generate();
+    assert(!transects.empty());
+    std::ofstream areaFile("output/area_transects.txt");
+    for (const auto& seg : transects) {
+        areaFile << seg.first.x << " " << seg.first.y << " "
+                 << seg.second.x << " " << seg.second.y << "\n";
+    }
+    areaFile.close();
+
+    // Corridor strip test
+    std::vector<Point> polyline = {{0,0},{100,0}};
+    CorridorStripPlanner stripPlanner(polyline, 40.0, 20.0);
+    auto strips = stripPlanner.generate();
+    assert(!strips.empty());
+    std::ofstream stripFile("output/corridor_transects.txt");
+    for (const auto& line : strips) {
+        for (size_t i=0;i<line.size();++i) {
+            stripFile << line[i].x << " " << line[i].y;
+            if (i+1 < line.size()) stripFile << ","; // delim between points
+        }
+        stripFile << "\n";
+    }
+    stripFile.close();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- update `path_planner` build to use C++17
- create `output/` directory automatically in the planner test

## Testing
- `cmake ..`
- `make`
- `./test_planner`
- `python ../python/plot_transects.py output`